### PR TITLE
Add Iridium Alloying back

### DIFF
--- a/scripts/TinkersConstruct.zs
+++ b/scripts/TinkersConstruct.zs
@@ -52,6 +52,9 @@ for slime, dirts in slimeDirts {
 	
 # Item Rack
 	rh(<tconstruct:rack>);
+
+# Iridium Alloying
+	mods.tconstruct.Alloy.addRecipe(<liquid:iridium>*48,[<liquid:platinum>*32,<liquid:silver>*32,<liquid:manasteel>*32]);
 	
 # Blank Cast Resmelting
 	mods.tconstruct.Melting.addRecipe(<liquid:alubrass> * 144, <tconstruct:cast>);


### PR DESCRIPTION
Lost in update to 1.90g [here](https://github.com/EnigmaticaModpacks/Enigmatica2ExpertSkyblock/pull/605/files#diff-96d93fb62c9ed6a7cf9f809f90de39829001621442c085101bdaf80676c1c0c9L17-L19)

Fixes https://github.com/EnigmaticaModpacks/Enigmatica2ExpertSkyblock/issues/611